### PR TITLE
fix for opf prefixes

### DIFF
--- a/src/OPF/Manifest/Manifest.ts
+++ b/src/OPF/Manifest/Manifest.ts
@@ -39,7 +39,10 @@ export default class Manifest {
 
   static loadFromXMLElement(element: XmlElement): Manifest | null {
     try {
-      const itemNodes = element.childrenNamed(ManifestItem.elementName)
+      let itemNodes = element.childrenNamed(ManifestItem.elementName)
+      if (itemNodes.length == 0) {
+        itemNodes = element.childrenNamed('opf:' + ManifestItem.elementName)
+      }
       const items: ManifestItem[] = []
       for (const node of itemNodes) {
         const item = ManifestItem.loadFromXMLElement(node)

--- a/src/OPF/Package.ts
+++ b/src/OPF/Package.ts
@@ -43,15 +43,19 @@ export default class Package {
     let epubPackage: Package | null = null
     try {
       const document = new XML.XmlDocument(xmlString)
-      const metadataNode = document.childNamed(Metadata.elementName)
+      const metadataNode =
+        document.childNamed(Metadata.elementName) ||
+        document.childNamed('opf:' + Metadata.elementName)
       if (metadataNode == null)
         throw new Error(`missing ${Metadata.elementName} from opf file`)
       const metadata = Metadata.loadFromXMLElement(metadataNode)
-      const manifestNode = document.childNamed('manifest')
+      const manifestNode =
+        document.childNamed('manifest') || document.childNamed('opf:manifest')
       if (manifestNode == null)
         throw new Error(`missing ${Manifest.elementName} from opf file`)
       const manifest = Manifest.loadFromXMLElement(manifestNode)
-      const spineNode = document.childNamed('spine')
+      const spineNode =
+        document.childNamed('spine') || document.childNamed('opf:spine')
       if (spineNode == null)
         throw new Error(`missing ${Spine.elementName} from opf file`)
       const spine = Spine.loadFromXMLElement(spineNode)

--- a/src/OPF/Spine.ts
+++ b/src/OPF/Spine.ts
@@ -53,7 +53,10 @@ export default class Spine {
   static loadFromXMLElement(element: XmlElement): Spine | null {
     let spine: Spine | null = null
     try {
-      const itemrefNodes = element.childrenNamed(Itemref.elementName)
+      let itemrefNodes = element.childrenNamed(Itemref.elementName)
+      if (itemrefNodes.length == 0) {
+        itemrefNodes = element.childrenNamed('opf:' + Itemref.elementName)
+      }
       const items: Itemref[] = []
       for (const node of itemrefNodes) {
         const item = Itemref.loadFromXMLElement(node)


### PR DESCRIPTION
Some manifests declare opf prefix and not use it while some don't declare it and use it.
This PR fix the issue by checking without the prefix first and then with the prefix