### PR TITLE
feat: reading progression default

### DIFF
--- a/src/EpubHelper.ts
+++ b/src/EpubHelper.ts
@@ -438,7 +438,7 @@ export default class EpubHelper {
     return this.epub.epubPackage.metadata.languages[0].contentText || 'en'
   }
 
-  readingDirection(): DIR {
+  readingDirection(): DIR | undefined {
     return this.epub.epubPackage.spine.pageProgressionDirection
   }
 }

--- a/src/OPF/Spine.ts
+++ b/src/OPF/Spine.ts
@@ -40,14 +40,13 @@ export default class Spine {
   static elementName = 'spine'
 
   id?: string
-  pageProgressionDirection: DIR
+  pageProgressionDirection?: DIR
   toc?: string
   pageMap?: string
   items: Itemref[]
 
   constructor(items: Itemref[]) {
     this.items = items
-    this.pageProgressionDirection = DIR.LTR
   }
 
   static loadFromXMLElement(element: XmlElement): Spine | null {
@@ -66,8 +65,12 @@ export default class Spine {
       }
       spine = new Spine(items)
       const direction = element.attr[SPINE_PROGRESSION_DIRECTION]
-      spine.pageProgressionDirection =
-        direction && direction == 'rtl' ? DIR.RTL : DIR.LTR
+
+      if (direction && direction === 'rtl') {
+        spine.pageProgressionDirection = DIR.RTL
+      } else if (direction && direction === 'ltr') {
+        spine.pageProgressionDirection = DIR.LTR
+      }
       const toc = element.attr.toc
       if (toc) {
         spine.toc = toc


### PR DESCRIPTION
ReadingProgression can be undefined or equal `default` according to W3C.

In this case, it should be kept undefined in the wpub manifest so the client app can react accordingly. 